### PR TITLE
Add grab/approach offsets, straight motion profile, and fix resource validation errors

### DIFF
--- a/definitions/pf400.info.yaml
+++ b/definitions/pf400.info.yaml
@@ -217,7 +217,7 @@ actions:
     blocking: false
     asynchronous: true
 config:
-  node_definition: /Users/dozgulbas/workspace/pf400_module/definitions/pf400.node.yaml
+  node_definition: definitions/pf400.node.yaml
   node_info_path: null
   update_node_files: true
   status_update_interval: 2.0

--- a/definitions/pf400.info.yaml
+++ b/definitions/pf400.info.yaml
@@ -95,7 +95,7 @@ actions:
     asynchronous: true
   place_plate:
     name: place_plate
-    description: Place a plate to a target location
+    description: Place a plate in a target location, optionally moving first to target_approach
     args: {}
     locations:
       target:
@@ -217,7 +217,7 @@ actions:
     blocking: false
     asynchronous: true
 config:
-  node_definition: definitions/pf400.node.yaml
+  node_definition: /Users/dozgulbas/workspace/pf400_module/definitions/pf400.node.yaml
   node_info_path: null
   update_node_files: true
   status_update_interval: 2.0
@@ -225,6 +225,8 @@ config:
   node_url: http://127.0.0.1:2000/
   uvicorn_kwargs: {}
   pf400_ip: null
+  pf400_port: 10100
+  pf400_status_port: 10000
 config_schema:
   description: Configuration for the pf400 node module.
   properties:
@@ -289,5 +291,13 @@ config_schema:
       - type: 'null'
       default: null
       title: Pf400 Ip
+    pf400_port:
+      default: 10100
+      title: Pf400 Port
+      type: integer
+    pf400_status_port:
+      default: 10000
+      title: Pf400 Status Port
+      type: integer
   title: PF400NodeConfig
   type: object

--- a/src/pf400_interface/pf400.py
+++ b/src/pf400_interface/pf400.py
@@ -847,16 +847,21 @@ class PF400(KINEMATICS):
             self.move_all_joints_neutral(approach.representation)
 
     def _calculate_above_position(
-        self, position: list, approach_height_offset: Optional[float] = None
+        self,
+        position: list,
+        approach_height_offset: Optional[float] = None,
+        grab_height_offset: Optional[float] = None,
     ) -> list:
         """
         Calculate the position above a target with optional height offset.
         """
+        above_offset = copy.deepcopy(self.default_approach_vector)
+
         if approach_height_offset:
-            above_offset = copy.deepcopy(self.default_approach_vector)
             above_offset[0] += approach_height_offset
-        else:
-            above_offset = self.default_approach_vector
+        if grab_height_offset:
+            above_offset[0] += grab_height_offset
+
         return list(map(add, position, above_offset))
 
     def _apply_grab_offset(self, position: list, grab_offset: float) -> list:
@@ -881,7 +886,7 @@ class PF400(KINEMATICS):
         Returns True if the plate was successfully grabbed, False otherwise.
         """
         above_position = self._calculate_above_position(
-            source.representation, approach_height_offset
+            source.representation, approach_height_offset, grab_offset
         )
         self.open_gripper()
 
@@ -940,7 +945,7 @@ class PF400(KINEMATICS):
         Place a plate in the target location
         """
         above_position = self._calculate_above_position(
-            target.representation, approach_height_offset
+            target.representation, approach_height_offset, grab_offset
         )
 
         if target_approach:
@@ -995,7 +1000,8 @@ class PF400(KINEMATICS):
         target_plate_rotation: str = "",
         rotation_deck: Optional[LocationArgument] = None,
         grab_offset: Optional[float] = None,
-        approach_height_offset: Optional[float] = None,
+        source_approach_height_offset: Optional[float] = None,
+        target_approach_height_offset: Optional[float] = None,
     ) -> None:
         """
         Description: Plate transfer function that performs series of movements to pick and place the plates
@@ -1008,7 +1014,8 @@ class PF400(KINEMATICS):
                         - target_plate_rotation: narrow or wide
                         - rotation_deck: Location for plate rotation deck
                         - grab_offset: Add grab height offset
-                        - approach_height_offset: Add approach height offset
+                        - source_approach_height_offset: Add source approach height offset
+                        - target_approach_height_offset: Add target approach height offset
 
                 Note: Plate rotation defines the rotation of the plate on the deck, not the grabbing angle.
         """
@@ -1038,7 +1045,7 @@ class PF400(KINEMATICS):
             source=source,
             source_approach=source_approach,
             grab_offset=grab_offset,
-            approach_height_offset=approach_height_offset,
+            approach_height_offset=source_approach_height_offset,
         )
 
         if not pick_result:
@@ -1075,5 +1082,5 @@ class PF400(KINEMATICS):
             target=target,
             target_approach=target_approach,
             grab_offset=grab_offset,
-            approach_height_offset=approach_height_offset,
+            approach_height_offset=target_approach_height_offset,
         )

--- a/src/pf400_interface/pf400.py
+++ b/src/pf400_interface/pf400.py
@@ -496,7 +496,7 @@ class PF400(KINEMATICS):
         # Verify gripper opened to target width
         current_gripper_position = self.get_gripper_position()
 
-        if abs(current_gripper_position - width) <= 1:
+        if abs(current_gripper_position - width) <= 5:
             return True
 
         self.logger.log_error(

--- a/src/pf400_interface/pf400.py
+++ b/src/pf400_interface/pf400.py
@@ -915,7 +915,10 @@ class PF400(KINEMATICS):
             )
 
         self.move_in_one_axis(
-            profile=self.slow_motion_profile, axis_z=self.default_approach_height
+            profile=self.slow_motion_profile,
+            axis_z=self.default_approach_height + approach_height_offset
+            if approach_height_offset
+            else self.default_approach_height,
         )
 
         if source_approach:
@@ -971,7 +974,10 @@ class PF400(KINEMATICS):
                 )
 
         self.move_in_one_axis(
-            profile=self.slow_motion_profile, axis_z=self.default_approach_height
+            profile=self.slow_motion_profile,
+            axis_z=self.default_approach_height + approach_height_offset
+            if approach_height_offset
+            else self.default_approach_height,
         )
 
         if target_approach:

--- a/src/pf400_interface/pf400.py
+++ b/src/pf400_interface/pf400.py
@@ -928,11 +928,13 @@ class PF400(KINEMATICS):
 
         if source_approach:
             self._handle_approach_location(source_approach)
+            approach_motion_profile = self.straight_motion_profile
         else:
             self.move_all_joints_neutral(source.representation)
+            approach_motion_profile = self.fast_motion_profile
 
         self.move_joint(
-            target_joint_angles=above_position, profile=self.straight_motion_profile
+            target_joint_angles=above_position, profile=approach_motion_profile
         )
 
         target_position = (
@@ -942,7 +944,7 @@ class PF400(KINEMATICS):
         )
         self.move_joint(
             target_joint_angles=target_position,
-            profile=self.straight_motion_profile,
+            profile=approach_motion_profile,
             gripper_open=True,
         )
         grab_succeeded = self.grab_plate(width=grip_width, speed=100, force=10)
@@ -956,7 +958,7 @@ class PF400(KINEMATICS):
             )
 
         self.move_in_one_axis(
-            profile=self.straight_motion_profile,
+            profile=self.slow_motion_profile,
             axis_z=self.default_approach_height + approach_height_offset
             if approach_height_offset
             else self.default_approach_height,
@@ -986,17 +988,19 @@ class PF400(KINEMATICS):
 
         if target_approach:
             self._handle_approach_location(target_approach)
+            approach_motion_profile = self.straight_motion_profile
         else:
             self.move_all_joints_neutral(target.representation)
+            approach_motion_profile = self.slow_motion_profile
 
-        self.move_joint(above_position, self.straight_motion_profile)
+        self.move_joint(above_position, approach_motion_profile)
 
         target_position = (
             self._apply_grab_offset(target.representation, grab_offset)
             if grab_offset
             else target.representation
         )
-        self.move_joint(target_position, self.straight_motion_profile)
+        self.move_joint(target_position, approach_motion_profile)
         release_succeeded = self.release_plate(width=open_width)
 
         if (
@@ -1016,7 +1020,7 @@ class PF400(KINEMATICS):
                 )
 
         self.move_in_one_axis(
-            profile=self.straight_motion_profile,
+            profile=self.fast_motion_profile,
             axis_z=self.default_approach_height + approach_height_offset
             if approach_height_offset
             else self.default_approach_height,

--- a/src/pf400_interface/pf400.py
+++ b/src/pf400_interface/pf400.py
@@ -387,7 +387,7 @@ class PF400(KINEMATICS):
     def set_profile(self, profile_dict: Optional[dict] = None) -> str:
         """
         Description: Sets and saves the motion profiles (defined in robot data) to the robot.
-                                If user defines a custom profile, this profile will saved onto motion profile 3 on the robot
+                                If user defines a custom profile, this profile will saved onto motion profile 4 on the robot
         Parameters:
                         - profile_dict: Custom motion profile
         """

--- a/src/pf400_interface/pf400_constants.py
+++ b/src/pf400_interface/pf400_constants.py
@@ -29,7 +29,7 @@ MOTION_PROFILES = [
         "straight": 0,
     },
     {
-        "speed": 30,
+        "speed": 70,
         "speed2": 0,
         "acceleration": 50,
         "deceleration": 50,

--- a/src/pf400_interface/pf400_constants.py
+++ b/src/pf400_interface/pf400_constants.py
@@ -28,6 +28,16 @@ MOTION_PROFILES = [
         "inrange": 0,
         "straight": 0,
     },
+    {
+        "speed": 30,
+        "speed2": 0,
+        "acceleration": 50,
+        "deceleration": 50,
+        "accelramp": 0.1,
+        "decelramp": 0.1,
+        "inrange": 0,
+        "straight": -1,
+    },
 ]
 
 ERROR_CODES = {

--- a/src/pf400_rest_node.py
+++ b/src/pf400_rest_node.py
@@ -181,6 +181,10 @@ class PF400Node(RestNode):
         rotation_deck: Annotated[
             LocationArgument, "Plate rotation deck location"
         ] = None,
+        grab_offset: Optional[Annotated[float, "Add grab height offset"]] = None,
+        approach_height_offset: Optional[
+            Annotated[float, "Add approach height offset"]
+        ] = None,
     ) -> None:
         """Transfer a plate from `source` to `target`, optionally using intermediate `approach` positions and target rotations."""
 
@@ -206,6 +210,8 @@ class PF400Node(RestNode):
             source_plate_rotation=source_plate_rotation,
             target_plate_rotation=target_plate_rotation,
             rotation_deck=rotation_deck if rotation_deck else None,
+            grab_offset=grab_offset,
+            approach_height_offset=approach_height_offset,
         )
 
     @action(name="pick_plate", description="Pick a plate from a source location")
@@ -218,6 +224,10 @@ class PF400Node(RestNode):
         source_plate_rotation: Annotated[
             str, "Orientation of the plate at the source, wide or narrow"
         ] = "",
+        grab_offset: Optional[Annotated[float, "Add grab height offset"]] = None,
+        approach_height_offset: Optional[
+            Annotated[float, "Add approach height offset"]
+        ] = None,
     ) -> None:
         """Picks a plate from `source`, optionally moving first to `source_approach`."""
         if source.resource_id:
@@ -245,6 +255,8 @@ class PF400Node(RestNode):
         pick_result = self.pf400_interface.pick_plate(
             source=source,
             source_approach=source_approach if source_approach else None,
+            grab_offset=grab_offset,
+            approach_height_offset=approach_height_offset,
         )
         if not pick_result:
             raise Exception(f"Failed to pick plate from location {source}.")
@@ -262,6 +274,10 @@ class PF400Node(RestNode):
         target_plate_rotation: Annotated[
             str, "Final orientation of the plate at the target, wide or narrow"
         ] = "",
+        grab_offset: Optional[Annotated[float, "Add grab height offset"]] = None,
+        approach_height_offset: Optional[
+            Annotated[float, "Add approach height offset"]
+        ] = None,
     ) -> None:
         """Place a plate in the `target` location, optionally moving first to `target_approach`."""
 
@@ -291,6 +307,8 @@ class PF400Node(RestNode):
         self.pf400_interface.place_plate(
             target=target,
             target_approach=target_approach if target_approach else None,
+            grab_offset=grab_offset,
+            approach_height_offset=approach_height_offset,
         )
 
     @action(name="remove_lid", description="Remove a lid from a plate")
@@ -311,6 +329,10 @@ class PF400Node(RestNode):
             str, "Final orientation of the plate at the target, wide or narrow"
         ] = "",
         lid_height: Annotated[float, "height of the lid, in steps"] = 7.0,
+        grab_offset: Optional[Annotated[float, "Add grab height offset"]] = None,
+        approach_height_offset: Optional[
+            Annotated[float, "Add approach height offset"]
+        ] = None,
     ) -> None:
         """Remove a lid from a plate located at location ."""
 
@@ -350,6 +372,8 @@ class PF400Node(RestNode):
             target_approach=target_approach,
             source_plate_rotation=source_plate_rotation,
             target_plate_rotation=target_plate_rotation,
+            grab_offset=grab_offset,
+            approach_height_offset=approach_height_offset,
         )
 
     @action(name="replace_lid", description="Replace a lid on a plate")
@@ -370,6 +394,10 @@ class PF400Node(RestNode):
             str, "Final orientation of the plate at the target, wide or narrow"
         ] = "",
         lid_height: Annotated[float, "height of the lid, in steps"] = 7.0,
+        grab_offset: Optional[Annotated[float, "Add grab height offset"]] = None,
+        approach_height_offset: Optional[
+            Annotated[float, "Add approach height offset"]
+        ] = None,
     ) -> None:
         """A doc string, but not the actual description of the action."""
 
@@ -398,6 +426,8 @@ class PF400Node(RestNode):
             target_approach=target_approach,
             source_plate_rotation=source_plate_rotation,
             target_plate_rotation=target_plate_rotation,
+            grab_offset=grab_offset,
+            approach_height_offset=approach_height_offset,
         )
 
         self.resource_client.remove_resource(lid_resource.resource_id)

--- a/src/pf400_rest_node.py
+++ b/src/pf400_rest_node.py
@@ -178,9 +178,7 @@ class PF400Node(RestNode):
         target_plate_rotation: Annotated[
             str, "Final orientation of the plate at the target, wide or narrow"
         ] = "",
-        rotation_deck: Annotated[
-            LocationArgument, "Plate rotation deck location"
-        ] = None,
+        rotation_deck: Optional[LocationArgument] = None,
         grab_offset: Optional[Annotated[float, "Add grab height offset"]] = None,
         approach_height_offset: Optional[
             Annotated[float, "Add approach height offset"]

--- a/src/pf400_rest_node.py
+++ b/src/pf400_rest_node.py
@@ -180,8 +180,11 @@ class PF400Node(RestNode):
         ] = "",
         rotation_deck: Optional[LocationArgument] = None,
         grab_offset: Optional[Annotated[float, "Add grab height offset"]] = None,
-        approach_height_offset: Optional[
-            Annotated[float, "Add approach height offset"]
+        source_approach_height_offset: Optional[
+            Annotated[float, "Add source approach height offset"]
+        ] = None,
+        target_approach_height_offset: Optional[
+            Annotated[float, "Add target approach height offset"]
         ] = None,
     ) -> None:
         """Transfer a plate from `source` to `target`, optionally using intermediate `approach` positions and target rotations."""
@@ -209,7 +212,8 @@ class PF400Node(RestNode):
             target_plate_rotation=target_plate_rotation,
             rotation_deck=rotation_deck if rotation_deck else None,
             grab_offset=grab_offset,
-            approach_height_offset=approach_height_offset,
+            source_approach_height_offset=source_approach_height_offset,
+            target_approach_height_offset=target_approach_height_offset,
         )
 
     @action(name="pick_plate", description="Pick a plate from a source location")


### PR DESCRIPTION
## Summary
This PR restores functionality from the WEI module, adds new features, and fixes minor bugs.

## New Features
- **Grab and approach height offsets**: Interface and REST Node actions now support custom height offsets for transfers
  - `grab_offset`: Adds a custom height offset to the default plate grab height
  - `approach_height_offset`: Adds an additional height offset to the approach waypoint
- **New motion profile**: Profile 3 added for straight motion parameters, enabling linear plane movement using joint angles
- **Straight motion for approach sequences**: Movements now use straight motion profile for the approach sequence:
  - Moving to above approach location
  - Moving from above approach location → target
  - Picking up/placing plates
  - Retreating from target → above approach location
  
  This ensures linear motion during critical pick and place operations.

## Bug Fixes
- Fixed resource validation errors that crashed the node when source locations were missing plates or targets were occupied. These now return `ActionFailed` responses to fail the workflow gracefully while keeping the PF400 node alive.

## Modified Files
- `src/pf400_interface/pf400.py`
- `src/pf400_rest_node.py`
- `src/pf400_interface/pf400_constants.py`

Closes #19 #21 #22 
---
