### PR TITLE
Add gripper_height_offset for location-specific pick/place clearance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,6 @@ Key methods:
 - `transfer(source, target, ...)` — full pick+place with optional approach waypoints and plate rotation
 - `pick_plate(source, ...)` / `place_plate(target, ...)` — individual pick/place
 - `remove_lid(source, target, lid_height=7.0, ...)` / `replace_lid(...)` — lid handling
-- `check_incorrect_plate_orientation(representation, rotation)` — corrects joint angles when orientation mismatches
 
 ### 3. `src/pf400_interface/pf400_kinematics.py` — Kinematics
 `KINEMATICS` base class with forward/inverse kinematics:

--- a/src/pf400_interface/pf400.py
+++ b/src/pf400_interface/pf400.py
@@ -713,8 +713,6 @@ class PF400:
         target_approach_height_offset: Optional[float] = None,
         source_height_limit: Optional[float] = None,
         target_height_limit: Optional[float] = None,
-        source_press_depth: Optional[float] = None,
-        target_press_depth: Optional[float] = None,
     ) -> bool:
         """Remove the lid from the plate"""
         if not lid_height:
@@ -735,8 +733,6 @@ class PF400:
             target_approach_height_offset=target_approach_height_offset,
             source_height_limit=source_height_limit,
             target_height_limit=target_height_limit,
-            source_press_depth=source_press_depth,
-            target_press_depth=target_press_depth,
         )
 
     def replace_lid(
@@ -753,8 +749,6 @@ class PF400:
         target_approach_height_offset: Optional[float] = None,
         source_height_limit: Optional[float] = None,
         target_height_limit: Optional[float] = None,
-        source_press_depth: Optional[float] = None,
-        target_press_depth: Optional[float] = None,
     ) -> bool:
         """Replace the lid on the plate"""
         if lid_height is None:
@@ -775,8 +769,6 @@ class PF400:
             target_approach_height_offset=target_approach_height_offset,
             source_height_limit=source_height_limit,
             target_height_limit=target_height_limit,
-            source_press_depth=source_press_depth,
-            target_press_depth=target_press_depth,
         )
 
     def rotate_plate_on_deck(
@@ -929,26 +921,12 @@ class PF400:
         approach_height_offset: Optional[float] = None,
         height_limit: Optional[float] = None,
         grip_width: Optional[int] = None,
-        press_depth: Optional[float] = None,
     ) -> bool:
         """
         Pick a plate from the source location, optionally using an approach location.
 
         Returns True if the plate was successfully grabbed, False otherwise.
         """
-
-        # TESTING
-        print("INTERFACE PICK PLATE")
-        print(f"{source=}")
-        print(f"{source_approach=}")
-        print(f"{grab_offset=}")
-        print(f"{height_limit=}")
-        print(f"{grip_width=}")
-        print(f"{press_depth=}")
-
-        if press_depth is not None:
-            source.representation = copy.deepcopy(source.representation)
-            source.representation[0] -= press_depth
 
         above_position = self._calculate_above_position(
             source.representation, approach_height_offset, grab_offset
@@ -1024,15 +1002,10 @@ class PF400:
         approach_height_offset: Optional[float] = None,
         height_limit: Optional[float] = None,
         open_width: Optional[int] = None,
-        press_depth: Optional[float] = None,
     ) -> bool:
         """
         Place a plate in the target location
         """
-        if press_depth is not None:
-            target.representation = copy.deepcopy(target.representation)
-            target.representation[0] -= press_depth
-
         above_position = self._calculate_above_position(
             target.representation, approach_height_offset, grab_offset
         )
@@ -1173,8 +1146,6 @@ class PF400:
         target_approach_height_offset: Optional[float] = None,
         source_height_limit: Optional[float] = None,
         target_height_limit: Optional[float] = None,
-        source_press_depth: Optional[float] = None,
-        target_press_depth: Optional[float] = None,
     ) -> bool:
         """
         Description: Plate transfer function that performs series of movements to pick and place the plates
@@ -1186,13 +1157,11 @@ class PF400:
                         - source_plate_rotation: narrow or wide
                         - target_plate_rotation: narrow or wide
                         - rotation_deck: Location for plate rotation deck
-                        - grab_offset: Add grab height offset
+                        - grab_offset: Add grab height offset (applied identically at pick and place)
                         - source_approach_height_offset: Add source approach height offset
                         - target_approach_height_offset: Add target approach height offset
                         - source_height_limit: Maximum height limit for source pick
                         - target_height_limit: Maximum height limit for target place
-                        - source_press_depth: Depth to press down when picking from source
-                        - target_press_depth: Depth to press down when placing to target
                 Returns:
                         True if transfer was successful, False otherwise.
 
@@ -1235,18 +1204,12 @@ class PF400:
             )
             return False
 
-        """
-        Depricating this implementation
-        source.representation = self.check_incorrect_plate_orientation(source.representation, plate_source_rotation)
-        """
-
         pick_result = self.pick_plate(
             source=source,
             source_approach=source_approach,
             grab_offset=grab_offset,
             approach_height_offset=source_approach_height_offset,
             height_limit=source_height_limit,
-            press_depth=source_press_depth,
         )
 
         if not pick_result:
@@ -1258,12 +1221,6 @@ class PF400:
         self.grip_wide = (
             target_plate_rotation and target_plate_rotation.lower() == "wide"
         )
-        """
-        Depricating this implementation
-        target.representation = self.check_incorrect_plate_orientation(
-            target.representation, plate_target_rotation
-        )
-        """
 
         # Rotate plate if needed
         if rotation_needed != 0:
@@ -1277,7 +1234,6 @@ class PF400:
             grab_offset=grab_offset,
             approach_height_offset=target_approach_height_offset,
             height_limit=target_height_limit,
-            press_depth=target_press_depth,
         )
         if not place_result:
             self.logger.error("Transfer failed: plate not released properly.")

--- a/src/pf400_rest_node.py
+++ b/src/pf400_rest_node.py
@@ -70,6 +70,11 @@ class PF400Node(RestNode):
                         "type": "number",  # or float?
                         "description": "Height limit on approach height. Used to ensure PF400 does not hit barriers above the location.",
                     },
+                    "gripper_height_offset": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Vertical offset (mm, >= 0) added to the pick/place Z so the gripper stays above obstacles around the location (e.g. an OT2 slot frame). Applied at both pick and place so the plate-bottom still lands on the calibrated surface.",
+                    },
                 },
                 "required": ["location", "plate_rotation"],
             },
@@ -95,6 +100,7 @@ class PF400Node(RestNode):
                 "payload_lb": 1.1,
                 "max_grip_force_newton": 23.0,
                 "grip_width_range": [80.0, 140.0],
+                "gripper_offset_applied": 0.0,
                 "description": "PF400 robot gripper slot",
             },
         )
@@ -219,6 +225,7 @@ class PF400Node(RestNode):
         Optional[str],
         Optional[float],
         Optional[float],
+        Optional[float],
     ]:
         """
         Parse a LocationArgument that may have a dictionary representation.
@@ -230,10 +237,13 @@ class PF400Node(RestNode):
             "plate_rotation": "wide" or "narrow"  # optional plate rotation
             "approach_height_offset": float  # optional approach height offset
             "height_limit": float  # optional height limit for validation
+            "gripper_height_offset": float  # optional pick/place clearance offset (>= 0)
         }
 
         Returns:
-            tuple: (location_arg_with_list_repr, approach_location_arg or None, plate_rotation or None, approach_height_offset or None, height_limit or None)
+            tuple: (location_arg_with_list_repr, approach_location_arg or None,
+                    plate_rotation or None, approach_height_offset or None,
+                    height_limit or None, gripper_height_offset or None)
         """
 
         if not isinstance(location.representation, dict):
@@ -251,7 +261,13 @@ class PF400Node(RestNode):
         plate_rotation = repr_dict.get("plate_rotation", None)
         approach_height_offset = repr_dict.get("approach_height_offset", None)
         height_limit = repr_dict.get("height_limit", None)
-        press_depth = repr_dict.get("press_depth", None)
+        gripper_height_offset = repr_dict.get("gripper_height_offset", None)
+
+        if gripper_height_offset is not None and gripper_height_offset < 0:
+            raise ValueError(
+                f"gripper_height_offset must be >= 0, got {gripper_height_offset}. "
+                "Locations are calibrated to the surface; descending lower is not supported via this field."
+            )
 
         parsed_location = LocationArgument(
             representation=location_repr,
@@ -274,13 +290,61 @@ class PF400Node(RestNode):
             plate_rotation,
             approach_height_offset,
             height_limit,
-            press_depth,
+            gripper_height_offset,
         )
+
+    def _get_gripper_offset_applied(self) -> float:
+        """Read the location-induced offset that was applied when the currently-held plate was picked.
+
+        Returns 0.0 if the gripper is empty or no offset was recorded.
+        """
+        gripper = self.resource_client.get_resource(self.gripper_resource.resource_id)
+        if not gripper.attributes:
+            return 0.0
+        value = gripper.attributes.get("gripper_offset_applied", 0.0)
+        return float(value) if value is not None else 0.0
+
+    def _set_gripper_offset_applied(self, value: float) -> None:
+        """Persist the location-induced offset used at pick (or 0.0 to clear after place)."""
+        gripper = self.resource_client.get_resource(self.gripper_resource.resource_id)
+        if gripper.attributes is None:
+            gripper.attributes = {}
+        gripper.attributes["gripper_offset_applied"] = float(value)
+        self.resource_client.update_resource(gripper)
+
+    def _validate_lid_clearance(
+        self,
+        plate_resource: Optional[object],
+        effective_grab_offset: float,
+    ) -> Optional[str]:
+        """Reject offsets large enough to drive the gripper fingers into the lid.
+
+        Returns an error message if the plate has a lid and the offset exceeds the
+        lid height; returns None otherwise. When ``has_lid`` is True but no
+        ``lid_height`` is recorded, the check is skipped with a warning since the
+        precise bound can't be computed.
+        """
+        if plate_resource is None or not plate_resource.attributes:
+            return None
+        if not plate_resource.attributes.get("has_lid"):
+            return None
+        lid_height = plate_resource.attributes.get("lid_height")
+        if lid_height is None:
+            self.logger.log_warning(
+                "Plate has_lid=True but no lid_height recorded; skipping grab-offset/lid clearance check."
+            )
+            return None
+        if effective_grab_offset > float(lid_height):
+            return (
+                f"Effective grab offset ({effective_grab_offset:.2f} mm) exceeds lid height "
+                f"({float(lid_height):.2f} mm); gripper fingers would reach the lid instead of the plate body."
+            )
+        return None
 
     @action(
         name="transfer", description="Transfer a plate from one location to another"
     )
-    def transfer(  # noqa: C901,
+    def transfer(  # noqa: C901, PLR0911
         self,
         source: Annotated[LocationArgument, "Location to pick a plate from"],
         target: Annotated[LocationArgument, "Location to place a plate to"],
@@ -289,6 +353,7 @@ class PF400Node(RestNode):
         """Transfer a plate from `source` to `target`, optionally using intermediate `approach` positions and target rotations."""
 
         grab_height_offset = None
+        plate_resource = None
         try:
             if source.resource_id:
                 source_resource = self.resource_client.get_resource(source.resource_id)
@@ -327,7 +392,7 @@ class PF400Node(RestNode):
                 source_rotation_from_dict,
                 source_approach_height_offset,
                 source_height_limit,
-                source_press_depth,
+                source_gripper_height_offset,
             ) = self._parse_location_representation(source)
             (
                 parsed_target,
@@ -335,7 +400,7 @@ class PF400Node(RestNode):
                 target_rotation_from_dict,
                 target_approach_height_offset,
                 target_height_limit,
-                target_press_depth,
+                target_gripper_height_offset,
             ) = self._parse_location_representation(target)
             if rotation_deck is not None:
                 (
@@ -353,6 +418,16 @@ class PF400Node(RestNode):
                 errors=[f"Failed to parse location representation: {e}"]
             )
 
+        location_offset = max(
+            source_gripper_height_offset or 0.0,
+            target_gripper_height_offset or 0.0,
+        )
+        effective_grab_offset = (grab_height_offset or 0.0) + location_offset
+
+        lid_error = self._validate_lid_clearance(plate_resource, effective_grab_offset)
+        if lid_error:
+            return ActionFailed(errors=[lid_error])
+
         transfer_result = self.pf400_interface.transfer(
             source=parsed_source,
             target=parsed_target,
@@ -361,19 +436,18 @@ class PF400Node(RestNode):
             source_plate_rotation=source_rotation_from_dict,
             target_plate_rotation=target_rotation_from_dict,
             rotation_deck=parsed_rotation,
-            grab_offset=grab_height_offset,
+            grab_offset=effective_grab_offset or None,
             source_approach_height_offset=source_approach_height_offset,
             target_approach_height_offset=target_approach_height_offset,
             source_height_limit=source_height_limit,
             target_height_limit=target_height_limit,
-            source_press_depth=source_press_depth,
-            target_press_depth=target_press_depth,
         )
         if not transfer_result:
             return ActionFailed(
                 errors=[f"Failed to transfer plate from {source} to {target}."]
             )
 
+        self._set_gripper_offset_applied(0.0)
         return None
 
     @action(name="pick_plate", description="Pick a plate from a source location")
@@ -383,6 +457,7 @@ class PF400Node(RestNode):
     ) -> Optional[ActionFailed]:
         """Picks a plate from `source`, optionally moving first to `source_approach`."""
         grab_height_offset = None
+        plate_resource = None
 
         import traceback
 
@@ -416,53 +491,58 @@ class PF400Node(RestNode):
                     source_rotation_from_dict,
                     source_approach_height_offset,
                     source_height_limit,
-                    press_depth,
+                    source_gripper_height_offset,
                 ) = self._parse_location_representation(source)
             except Exception as e:
                 return ActionFailed(
                     errors=[f"Failed to parse location representation: {e}"]
                 )
 
-            plate_source_rotation = (
-                90
-                if source_rotation_from_dict
-                and source_rotation_from_dict.lower() == "wide"
-                else 0
-            )
             self.pf400_interface.grip_wide = (
                 source_rotation_from_dict
                 and source_rotation_from_dict.lower() == "wide"
             )
 
+            location_offset = source_gripper_height_offset or 0.0
+            effective_grab_offset = (grab_height_offset or 0.0) + location_offset
+
+            lid_error = self._validate_lid_clearance(
+                plate_resource, effective_grab_offset
+            )
+            if lid_error:
+                return ActionFailed(errors=[lid_error])
+
             pick_result = self.pf400_interface.pick_plate(
                 source=parsed_source,
                 source_approach=source_approach,
-                grab_offset=grab_height_offset,
+                grab_offset=effective_grab_offset or None,
                 approach_height_offset=source_approach_height_offset,
                 height_limit=source_height_limit,
-                press_depth=press_depth,
             )
             if not pick_result:
                 return ActionFailed(
                     errors=[f"Failed to pick plate from location {source}."]
                 )
+
+            self._set_gripper_offset_applied(location_offset)
             return None
 
         except Exception:
-            self.logger.log_erorr(traceback.format_exc())
+            self.logger.log_error(traceback.format_exc())
             raise
 
     @action(
         name="place_plate",
         description="Place a plate in a target location, optionally moving first to target_approach",
     )
-    def place_plate(
+    def place_plate(  # noqa: C901
         self,
         target: Annotated[LocationArgument, "Location to place a plate to"],
     ) -> Optional[ActionFailed]:
         """Place a plate in the `target` location, optionally moving first to `target_approach`."""
 
         grab_height_offset = None
+        gripper_offset_applied = 0.0
         try:
             if target.resource_id:
                 target_resource = self.resource_client.get_resource(target.resource_id)
@@ -476,6 +556,11 @@ class PF400Node(RestNode):
                 gripper_resource = self.resource_client.get_resource(
                     self.gripper_resource.resource_id
                 )
+                if gripper_resource.attributes:
+                    gripper_offset_applied = float(
+                        gripper_resource.attributes.get("gripper_offset_applied", 0.0)
+                        or 0.0
+                    )
                 if gripper_resource.quantity > 0 and gripper_resource.children:
                     plate_in_gripper = gripper_resource.children[-1]
                     if plate_in_gripper.attributes:
@@ -484,7 +569,7 @@ class PF400Node(RestNode):
                         )
         except Exception as e:
             return ActionFailed(
-                errors=[f"Resource manager error during pick validation: {e}"]
+                errors=[f"Resource manager error during place validation: {e}"]
             )
 
         try:
@@ -494,35 +579,44 @@ class PF400Node(RestNode):
                 target_rotation_from_dict,
                 target_approach_height_offset,
                 target_height_limit,
-                press_depth,
+                target_gripper_height_offset,
             ) = self._parse_location_representation(target)
         except Exception as e:
             return ActionFailed(
                 errors=[f"Failed to parse location representation: {e}"]
             )
 
-        plate_target_rotation = (
-            90
-            if target_rotation_from_dict and target_rotation_from_dict.lower() == "wide"
-            else 0
-        )
+        target_loc_offset = target_gripper_height_offset or 0.0
+        if target_loc_offset > gripper_offset_applied:
+            return ActionFailed(
+                errors=[
+                    f"Target requires {target_loc_offset:.2f} mm gripper clearance but plate "
+                    f"was picked with only {gripper_offset_applied:.2f} mm offset. Re-pick the "
+                    "plate with adequate offset, or reduce gripper_height_offset on the target."
+                ]
+            )
+
         self.pf400_interface.grip_wide = (
             target_rotation_from_dict and target_rotation_from_dict.lower() == "wide"
+        )
+
+        effective_grab_offset = (grab_height_offset or 0.0) + max(
+            gripper_offset_applied, target_loc_offset
         )
 
         place_result = self.pf400_interface.place_plate(
             target=parsed_target,
             target_approach=target_approach,
-            grab_offset=grab_height_offset,
+            grab_offset=effective_grab_offset or None,
             approach_height_offset=target_approach_height_offset,
             height_limit=target_height_limit,
-            press_depth=press_depth,
         )
         if not place_result:
             return ActionFailed(
                 errors=["Transfer failed: plate not released properly."]
             )
 
+        self._set_gripper_offset_applied(0.0)
         return None
 
     @action(
@@ -539,10 +633,10 @@ class PF400Node(RestNode):
             (
                 parsed_target,
                 target_approach,
-                target_rotation_from_dict,
+                _target_rotation_from_dict,
                 target_approach_height_offset,
-                target_height_limit,
-                press_depth,
+                _target_height_limit,
+                target_gripper_height_offset,
             ) = self._parse_location_representation(target)
         except Exception as e:
             return ActionFailed(
@@ -552,7 +646,7 @@ class PF400Node(RestNode):
         self.pf400_interface.move_to_location(
             target=parsed_target,
             target_approach=target_approach or None,
-            grab_offset=None,  # move to location does not grab labware.
+            grab_offset=target_gripper_height_offset,
             approach_height_offset=target_approach_height_offset,
         )
 
@@ -651,7 +745,7 @@ class PF400Node(RestNode):
                 source_rotation_from_dict,
                 source_approach_height_offset,
                 source_height_limit,
-                source_press_depth,
+                source_gripper_height_offset,
             ) = self._parse_location_representation(source)
             (
                 parsed_target,
@@ -659,7 +753,7 @@ class PF400Node(RestNode):
                 target_rotation_from_dict,
                 target_approach_height_offset,
                 target_height_limit,
-                target_press_depth,
+                target_gripper_height_offset,
             ) = self._parse_location_representation(target)
         except Exception as e:
             return ActionFailed(
@@ -667,6 +761,12 @@ class PF400Node(RestNode):
             )
 
         parsed_source.resource_id = lid_resource.resource_id
+
+        location_offset = max(
+            source_gripper_height_offset or 0.0,
+            target_gripper_height_offset or 0.0,
+        )
+        effective_grab_offset = (grab_height_offset or 0.0) + location_offset
 
         remove_lid_result = self.pf400_interface.remove_lid(
             source=parsed_source,
@@ -676,17 +776,17 @@ class PF400Node(RestNode):
             target_approach=target_approach,
             source_plate_rotation=source_rotation_from_dict,
             target_plate_rotation=target_rotation_from_dict,
-            grab_offset=grab_height_offset,
+            grab_offset=effective_grab_offset or None,
             source_approach_height_offset=source_approach_height_offset,
             target_approach_height_offset=target_approach_height_offset,
             source_height_limit=source_height_limit,
             target_height_limit=target_height_limit,
-            source_press_depth=source_press_depth,
-            target_press_depth=target_press_depth,
         )
 
         if not remove_lid_result:
             return ActionFailed(errors=["Failed to remove lid."])
+
+        self._set_gripper_offset_applied(0.0)
 
         if plate_resource and plate_resource.attributes:
             plate_resource.attributes["has_lid"] = False
@@ -748,7 +848,7 @@ class PF400Node(RestNode):
                 source_rotation_from_dict,
                 source_approach_height_offset,
                 source_height_limit,
-                source_press_depth,
+                source_gripper_height_offset,
             ) = self._parse_location_representation(source)
             (
                 parsed_target,
@@ -756,7 +856,7 @@ class PF400Node(RestNode):
                 target_rotation_from_dict,
                 target_approach_height_offset,
                 target_height_limit,
-                target_press_depth,
+                target_gripper_height_offset,
             ) = self._parse_location_representation(target)
         except Exception as e:
             return ActionFailed(
@@ -764,6 +864,12 @@ class PF400Node(RestNode):
             )
 
         parsed_target.resource_id = lid_resource.resource_id
+
+        location_offset = max(
+            source_gripper_height_offset or 0.0,
+            target_gripper_height_offset or 0.0,
+        )
+        effective_grab_offset = (grab_height_offset or 0.0) + location_offset
 
         replace_lid_result = self.pf400_interface.replace_lid(
             source=parsed_source,
@@ -773,16 +879,16 @@ class PF400Node(RestNode):
             target_approach=target_approach,
             source_plate_rotation=source_rotation_from_dict,
             target_plate_rotation=target_rotation_from_dict,
-            grab_offset=grab_height_offset,
+            grab_offset=effective_grab_offset or None,
             source_approach_height_offset=source_approach_height_offset,
             target_approach_height_offset=target_approach_height_offset,
             source_height_limit=source_height_limit,
             target_height_limit=target_height_limit,
-            source_press_depth=source_press_depth,
-            target_press_depth=target_press_depth,
         )
         if not replace_lid_result:
             return ActionFailed(errors=["Failed to replace lid."])
+
+        self._set_gripper_offset_applied(0.0)
 
         self.resource_client.remove_resource(lid_resource.resource_id)
 

--- a/tests/test_pf400_node.ipynb
+++ b/tests/test_pf400_node.ipynb
@@ -736,6 +736,349 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "goff-a118787d",
+   "metadata": {},
+   "source": [
+    "## Location-Specific Gripper Offset Tests (v0.8)\n",
+    "\n",
+    "The new `gripper_height_offset` field on a location's dict representation raises the gripper Z by N mm at both pick and place, so the plate-bottom still lands on the calibrated surface even when the location has a frame/lip the gripper fingers would otherwise collide with (e.g. an OT2 slot). Tests below exercise the propagation, the `max(source, target)` rule, the cross-action state on the gripper resource, and the two validation paths."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-28f54521",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Test 13: Transfer with source-only gripper_height_offset (e.g. source is an OT2 slot with a 2mm frame)\n",
+    "# Expected: pick descends to source_Z + 2; place descends to target_Z + 2 so the plate still lands on the target surface.\n",
+    "request = ActionRequest(\n",
+    "    action_name=\"transfer\",\n",
+    "    args={\n",
+    "        \"source\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": source_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "                \"gripper_height_offset\": 2.0,\n",
+    "            },\n",
+    "            resource_id=source_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "        \"target\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": target_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "            },\n",
+    "            resource_id=target_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "    },\n",
+    ")\n",
+    "print(\"Test 13: Transfer with source gripper_height_offset = 2mm\")\n",
+    "response = client.send_action(action_request=request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-5d42c2f5",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.get_action_result(response.action_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-f1b54904",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Test 14: Transfer with gripper_height_offset on BOTH source and target.\n",
+    "# Expected: max(source, target) = 3mm is applied at both pick and place.\n",
+    "request = ActionRequest(\n",
+    "    action_name=\"transfer\",\n",
+    "    args={\n",
+    "        \"source\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": source_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "                \"gripper_height_offset\": 2.0,\n",
+    "            },\n",
+    "            resource_id=source_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "        \"target\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": target_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "                \"gripper_height_offset\": 3.0,\n",
+    "            },\n",
+    "            resource_id=target_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "    },\n",
+    ")\n",
+    "print(\"Test 14: Transfer with both source (2mm) and target (3mm) gripper_height_offset\")\n",
+    "response = client.send_action(action_request=request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-ecc6f7b8",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.get_action_result(response.action_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "goff-027a2b7c",
+   "metadata": {},
+   "source": [
+    "### Separated pick + place \u2014 `gripper_offset_applied` cross-action state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-bf661b8b",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Test 15a: pick_plate with a 2mm gripper_height_offset on source.\n",
+    "# Side effect: writes gripper_offset_applied = 2.0 onto the gripper resource attributes.\n",
+    "pick_request = ActionRequest(\n",
+    "    action_name=\"pick_plate\",\n",
+    "    args={\n",
+    "        \"source\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": source_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "                \"gripper_height_offset\": 2.0,\n",
+    "            },\n",
+    "            resource_id=source_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "    },\n",
+    ")\n",
+    "print(\"Test 15a: pick_plate with gripper_height_offset = 2mm\")\n",
+    "client.send_action(action_request=pick_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-81ae6c78",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.get_action_result(pick_request.action_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-f73a7cc3",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Test 15b: place_plate at a target with NO gripper_height_offset.\n",
+    "# Expected: place reads gripper_offset_applied (2.0) and uses max(2.0, 0.0) = 2.0 \u2014 plate lands on target surface,\n",
+    "# and gripper_offset_applied is cleared back to 0 afterwards.\n",
+    "place_request = ActionRequest(\n",
+    "    action_name=\"place_plate\",\n",
+    "    args={\n",
+    "        \"target\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": target_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "            },\n",
+    "            resource_id=target_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "    },\n",
+    ")\n",
+    "print(\"Test 15b: place_plate at target \u2014 should reuse pick-time 2mm offset\")\n",
+    "client.send_action(action_request=place_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-7c3f19b5",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.get_action_result(place_request.action_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "goff-5f8a907a",
+   "metadata": {},
+   "source": [
+    "### Validation \u2014 target requires more clearance than was applied at pick"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-9d288a61",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Test 16a: pick_plate with 2mm offset (same as 15a).\n",
+    "pick_request = ActionRequest(\n",
+    "    action_name=\"pick_plate\",\n",
+    "    args={\n",
+    "        \"source\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": source_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "                \"gripper_height_offset\": 2.0,\n",
+    "            },\n",
+    "            resource_id=source_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "    },\n",
+    ")\n",
+    "print(\"Test 16a: pick_plate with gripper_height_offset = 2mm\")\n",
+    "client.send_action(action_request=pick_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-c2d46f1e",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.get_action_result(pick_request.action_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-0a188084",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Test 16b: place_plate at a target requiring 5mm clearance \u2014 MORE than the 2mm applied at pick.\n",
+    "# Expected: ActionFailed with a clear message. The robot does NOT move toward the target,\n",
+    "# and the held plate stays in the gripper so the workflow can re-pick or fix the location config.\n",
+    "place_request = ActionRequest(\n",
+    "    action_name=\"place_plate\",\n",
+    "    args={\n",
+    "        \"target\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": target_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "                \"gripper_height_offset\": 5.0,\n",
+    "            },\n",
+    "            resource_id=target_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "    },\n",
+    ")\n",
+    "print(\"Test 16b: place_plate at target needing 5mm \u2014 should ActionFailed (target > applied)\")\n",
+    "client.send_action(action_request=place_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-f5863d5e",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.get_action_result(place_request.action_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "goff-316c1e70",
+   "metadata": {},
+   "source": [
+    "### Validation \u2014 effective grab offset would reach into the lid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-c681c3ae",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Test 17: Transfer where the source plate has has_lid=True and lid_height=2.0 (see Test Setup cell).\n",
+    "# An effective grab offset > lid_height risks the gripper fingers landing on the lid instead of the plate body,\n",
+    "# so the action should fail before any motion.\n",
+    "request = ActionRequest(\n",
+    "    action_name=\"transfer\",\n",
+    "    args={\n",
+    "        \"source\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": source_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "                \"gripper_height_offset\": 3.0,\n",
+    "            },\n",
+    "            resource_id=source_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "        \"target\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": target_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "            },\n",
+    "            resource_id=target_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "    },\n",
+    ")\n",
+    "print(\"Test 17: Transfer with gripper_height_offset (3mm) > plate lid_height (2mm) \u2014 should ActionFailed\")\n",
+    "response = client.send_action(action_request=request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-4ec4035a",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.get_action_result(response.action_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "goff-d02331c2",
+   "metadata": {},
+   "source": [
+    "### Calibration \u2014 drive to a framed-slot pick height without picking"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "goff-c934b036",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Test 18: move_to_location with gripper_height_offset, useful for visually verifying frame clearance.\n",
+    "# The robot descends to source_Z + 2 with the gripper open, then stays. Use move_neutral to retract.\n",
+    "request = ActionRequest(\n",
+    "    action_name=\"move_to_location\",\n",
+    "    args={\n",
+    "        \"target\": LocationArgument(\n",
+    "            representation={\n",
+    "                \"location\": source_loc,\n",
+    "                \"plate_rotation\": \"narrow\",\n",
+    "                \"gripper_height_offset\": 2.0,\n",
+    "            },\n",
+    "            resource_id=source_resource_id,\n",
+    "        ).model_dump(mode=\"json\"),\n",
+    "    },\n",
+    ")\n",
+    "print(\"Test 18: move_to_location with gripper_height_offset = 2mm (calibration check)\")\n",
+    "client.send_action(action_request=request)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Adds a per-location `gripper_height_offset` (mm, >= 0) on the deck location template so the PF400 can clear frames/lips around target slots (e.g. OT2) while the plate-bottom still lands on the calibrated surface. The same offset is applied at both pick AND place — the geometry cancels out, so the plate ends up in the right spot.

Also removes the never-used `press_depth` parameter, drops the orphaned `check_incorrect_plate_orientation` call sites, and extends `tests/test_pf400_node.ipynb` with 6 new live-robot tests covering the new behaviour.

## What changed

**`src/pf400_rest_node.py`**
- New `gripper_height_offset` field in the `pf400_deck_location_template` schema, extracted by `_parse_location_representation`. Negative values are rejected at parse time (locations are calibrated to the surface — descending below surface is not supported via this field).
- New `gripper_offset_applied` attribute on the `pf400_gripper` resource (default `0.0`).
- Helpers: `_get_gripper_offset_applied` / `_set_gripper_offset_applied` for cross-action state, `_validate_lid_clearance` for the lid check.
- `transfer` / `remove_lid` / `replace_lid`: effective offset = `(plate.grab_height_offset or 0) + max(source_loc, target_loc)`, applied at both pick and place. Lid validation runs in `transfer` only (the lid actions are *meant* to grab the lid).
- `pick_plate`: applies source's location offset; on success writes `gripper_offset_applied = source_loc_offset` onto the gripper resource so a later `place_plate` can recover it.
- `place_plate`: reads `gripper_offset_applied` from the gripper resource. If `target_loc_offset > gripper_offset_applied`, returns `ActionFailed` with a clear message rather than dropping the plate (the plate is hanging only `gripper_offset_applied` mm low in the gripper — fingers can't clear a deeper target frame). Otherwise uses `max(applied, target_loc)`, then clears `gripper_offset_applied` to 0 after release.
- `move_to_location`: now passes the target's `gripper_height_offset` so calibration descents match a real pick.
- Drops all `press_depth` plumbing. Also fixed an unrelated `log_erorr` typo while in the same function.

**`src/pf400_interface/pf400.py`**
- Removes `press_depth` / `source_press_depth` / `target_press_depth` from `pick_plate`, `place_plate`, `transfer`, `remove_lid`, `replace_lid` (signatures, bodies, and `transfer`'s docstring).
- Removes a leftover `# TESTING` debug `print` block at the top of `pick_plate`.
- Removes two orphaned `self.check_incorrect_plate_orientation(...)` call sites (commented-out as deprecated; the method itself was already deleted).

**`AGENTS.md`**
- Drops the stale `check_incorrect_plate_orientation` bullet from Key Methods.

**`tests/test_pf400_node.ipynb`**
- Removes the obsolete `press_depth: 5.0` line from Test 2.
- Adds Tests 13-18 against the live robot:
  - 13: transfer with source-only offset
  - 14: transfer with both source and target offsets (max rule)
  - 15a/b: separated pick + place, place inherits offset via gripper resource
  - 16a/b: place errors when target needs more clearance than was applied at pick
  - 17: transfer errors when effective offset > plate `lid_height` and `has_lid=True`
  - 18: `move_to_location` with offset for calibration

## Geometric rationale

When picking with `gripper_height_offset = N` (gripper-Z = `saved_source_Z + N`), the gripper fingers grip the plate's side wall `N` mm higher up. After grip, the plate hangs `N` mm lower (in absolute world Z) below the gripper-reference than a normally-gripped plate would. To release the plate so its bottom lands on `target_surface_Z`, the gripper must also descend less by `N` mm (gripper-Z = `saved_target_Z + N`). Same offset, same sign, both ends.

A target requiring *more* clearance than was applied at pick is geometrically unsatisfiable (the plate isn't hanging low enough to release above a deeper frame), which is why `place_plate` errors out.

## Test plan

- [ ] Pull this branch on the PF400 host and restart the rest node so the new `pf400_gripper` template picks up `gripper_offset_applied: 0.0`.
- [ ] Run Tests 1-12 in `test_pf400_node.ipynb` to confirm no regressions in existing behaviour.
- [ ] Run Test 13 — verify pick/place succeed with source-only 2mm offset.
- [ ] Run Test 14 — verify both ends use 3mm.
- [ ] Run Test 15a then 15b — verify place succeeds and plate lands correctly with no target offset.
- [ ] Run Test 16a then 16b — verify 16b returns `ActionFailed` with the "target requires X mm but plate was picked with only Y mm" message; plate should still be in the gripper after the error.
- [ ] Run Test 17 — verify transfer returns `ActionFailed` before any motion when offset (3mm) exceeds plate `lid_height` (2mm).
- [ ] Run Test 18 — verify `move_to_location` descends to source_Z + 2mm; visually confirm frame clearance.
- [ ] After Test 16b's error, run a `place_plate` with a 2mm or smaller target offset to confirm the plate can be placed (clear the held plate and gripper state for downstream tests).
